### PR TITLE
Add lxml dependency for FantasyPros parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.32.3
 streamlit==1.35.0
 nfl-data-py==0.3.1
 pytest==8.2.1
+lxml==5.2.2


### PR DESCRIPTION
## Summary
- add lxml to the requirements so pandas.read_html has an HTML parser available

## Testing
- pip install -r requirements.txt *(fails: ProxyError cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d01230223883239f4646e62784ca9b